### PR TITLE
Do not set omero.glacier2.IceSSL.Ciphers on OS X environments

### DIFF
--- a/omero_certificates/certificates.py
+++ b/omero_certificates/certificates.py
@@ -7,6 +7,7 @@ Wrap openssl to manage self-signed certificates
 import logging
 import os
 import subprocess
+import sys
 from omero.config import ConfigXml
 
 log = logging.getLogger(__name__)
@@ -36,7 +37,8 @@ def update_config(omerodir):
     set_if_empty("omero.glacier2.IceSSL.CAs", "server.pem")
     set_if_empty("omero.glacier2.IceSSL.Password", "secret")
 
-    set_if_empty("omero.glacier2.IceSSL.Ciphers", "HIGH")
+    if sys.platform != "darwin":
+        set_if_empty("omero.glacier2.IceSSL.Ciphers", "HIGH")
     set_if_empty("omero.glacier2.IceSSL.ProtocolVersionMax", "TLS1_2")
     set_if_empty("omero.glacier2.IceSSL.Protocols", "TLS1_0,TLS1_1,TLS1_2")
 


### PR DESCRIPTION
Encountered during the deployment of a local development server (OS X 12.6, Java 11, Python 3.8, OpenSSL 1.1.1) after configuring the local self-signed certificates using `omero certificates`. Using the current version of `omero-py`, the connections to the server were broken:

```
(omeroserver) sbesson@Sebastiens-MacBook-Pro-2 omero-certificates % omero config get                   
omero.certificates.commonname=localhost
omero.certificates.key=server.key
omero.certificates.owner=/L=OMERO/O=OMERO.server
omero.data.dir=/Users/sbesson/OMERO.repo
omero.glacier2.IceSSL.CAs=server.pem
omero.glacier2.IceSSL.CertFile=server.p12
omero.glacier2.IceSSL.Ciphers=HIGH
omero.glacier2.IceSSL.DefaultDir=/Users/sbesson/OMERO.repo/certs
omero.glacier2.IceSSL.Password=********
omero.glacier2.IceSSL.ProtocolVersionMax=TLS1_2
omero.glacier2.IceSSL.Protocols=TLS1_0,TLS1_1,TLS1_2
(omeroserver) sbesson@Sebastiens-MacBook-Pro-2 omero-certificates % omero admin start
WARNING: Your server has not been configured for production use.
See https://docs.openmicroscopy.org/omero/latest/sysadmins/server-performance.html?highlight=poolsize
for more information.
No descriptor given. Using etc/grid/default.xml
Waiting on startup. Use CTRL-C to exit
(omeroserver) sbesson@Sebastiens-MacBook-Pro-2 omero-certificates % grep SSL /opt/OMERO.current/var/log/master.err 
   plug-in initialization failed: IceSSL: no such cipher HIGH
(omeroserver) sbesson@Sebastiens-MacBook-Pro-2 omero-certificates % omero login root@localhost
Previous session expired for root on localhost:4064
Password:
Ice.ConnectionRefusedException: localhost isn't running
```

After removing `omero.glacier2.IceSSL.Ciphers` following a discussion with @chris-allan and restarting the server:

```
(omeroserver) sbesson@Sebastiens-MacBook-Pro-2 omero-certificates % omero config set omero.glacier2.IceSSL.Ciphers
(omeroserver) sbesson@Sebastiens-MacBook-Pro-2 omero-certificates % omero admin restart 
Waiting on shutdown. Use CTRL-C to exit
.WARNING: Your server has not been configured for production use.
See https://docs.openmicroscopy.org/omero/latest/sysadmins/server-performance.html?highlight=poolsize
for more information.
No descriptor given. Using etc/grid/default.xml
Waiting on startup. Use CTRL-C to exit
(omeroserver) sbesson@Sebastiens-MacBook-Pro-2 omero-certificates %  omero login root@localhost
Previously logged in to localhost:4064 as root
Password:
Created session for root@localhost:4064. Idle timeout: 10 min. Current group: system
```

This is an edge case and potentially something we don't necessarily want to handle in this plugin anyways as OS X is not part of the operating systems we officially support. But at minimum this PR can act as a knowledge base for anyone running into a similar issue
