### PR TITLE
Port to Python cryptography module

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ For full information see the output of:
 omero certificates --help
 ```
 
+## Upgrading
+
+Since version 0.3.0 this plugin uses portable RFC 4514 (supercedes RFC 2253) formatted strings for the `omero.certificates.owner` configuration option.  If you have ran `omero certificates` before you may have OpenSSL command line formatted strings in your configuration that need to be updated before you can run `omero certificates` again.  In most cases this means taking a string such as `/L=OMERO/O=OMERO.server` and reformatting it to `L=OMERO,O=OMERO.server`; remove the leading `/` and replace separator `/`'s with `,`'s.
+
+You can see the RFC 4514 compatible string for the `Issuer` and `Subject` of your existing certificate by running:
+```
+openssl x509 -in /path/to/cert.pem -text -nameopt rfc2253
+```
+
+You can review the RFC in full for more specific details:
+- https://tools.ietf.org/html/rfc4514.html
+
 ## Developer notes
 
 This project uses [setuptools-scm](https://pypi.org/project/setuptools-scm/).

--- a/README.md
+++ b/README.md
@@ -10,12 +10,10 @@ If you prefer to configure OMERO manually see the examples in these documents:
 
 ## Installation
 
-Install `openssl` if it's not already on your system.
-Then activate your OMERO.server virtualenv and run:
+Activate your OMERO.server virtualenv and run:
 ```
 pip install omero-certificates
 ```
-
 
 ## Usage
 
@@ -26,11 +24,6 @@ Run:
 omero certificates
 ```
 ```
-OpenSSL 1.1.1d  10 Sep 2019
-Generating RSA private key, 2048 bit long modulus (2 primes)
-.+++++
-.............................+++++
-e is 65537 (0x010001)
 certificates created: /OMERO/certs/server.key /OMERO/certs/server.pem /OMERO/certs/server.p12
 ```
 to update your OMERO.server configuration and to generate or update your self-signed certificates.
@@ -46,12 +39,6 @@ The original values can be found on https://docs.openmicroscopy.org/omero/5.6.0/
 
 Certificates will be stored under `{omero.data.dir}/certs` by default.
 Set `omero.glacier2.IceSSL.DefaultDir` to change this.
-
-If you see a warning message such as
-```
-Can't load ./.rnd into RNG
-```
-it should be safe to ignore.
 
 For full information see the output of:
 ```

--- a/omero_certificates/certificates.py
+++ b/omero_certificates/certificates.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-Wrap openssl to manage self-signed certificates
+Wrap cryptography to manage self-signed certificates
 """
 
 import logging
 import os
-import subprocess
 from datetime import datetime, timedelta
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
@@ -57,12 +56,6 @@ def update_config(omerodir):
     return cfgdict
 
 
-def run_openssl(args):
-    command = ["openssl"] + args
-    log.info("Executing: %s", " ".join(command))
-    subprocess.run(command)
-
-
 def create_certificates(omerodir):
     cfgmap = update_config(omerodir)
     certdir = cfgmap["omero.glacier2.IceSSL.DefaultDir"]
@@ -74,13 +67,6 @@ def create_certificates(omerodir):
     keypath = os.path.join(certdir, cfgmap["omero.certificates.key"])
     certpath = os.path.join(certdir, cfgmap["omero.glacier2.IceSSL.CAs"])
     password = cfgmap["omero.glacier2.IceSSL.Password"]
-
-    try:
-        run_openssl(["version"])
-    except subprocess.CalledProcessError as e:
-        msg = "openssl version failed, is it installed?"
-        log.fatal("%s: %s", msg, e)
-        raise
 
     os.makedirs(certdir, exist_ok=True)
     created_files = []

--- a/omero_certificates/certificates.py
+++ b/omero_certificates/certificates.py
@@ -97,7 +97,14 @@ def create_certificates(omerodir):
     log.info("Creating self-signed certificate: %s", certpath)
     # Do what `openssl req -x509 ...` would do
     utcnow = datetime.utcnow()
-    subject = issuer = x509.Name.from_rfc4514_string("{},CN={}".format(owner, cn))
+    try:
+        subject = issuer = x509.Name.from_rfc4514_string("{},CN={}".format(owner, cn))
+    except ValueError:
+        return (
+            f"'omero.certificates.owner' configuration setting '{owner}' not a "
+            "valid RFC 4514 string!  Are you upgrading?  See "
+            "https://pypi.org/project/omero-certificates/ for help."
+        )
     cert = (
         x509.CertificateBuilder()
         .subject_name(subject)

--- a/omero_certificates/certificates.py
+++ b/omero_certificates/certificates.py
@@ -7,7 +7,11 @@ Wrap openssl to manage self-signed certificates
 import logging
 import os
 import subprocess
+from datetime import datetime, timedelta
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.hashes import SHA256
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
     NoEncryption,
@@ -36,7 +40,7 @@ def update_config(omerodir):
         os.path.join(cfgdict.get("omero.data.dir", "/OMERO"), "certs"),
     )
     set_if_empty("omero.certificates.commonname", "localhost")
-    set_if_empty("omero.certificates.owner", "/L=OMERO/O=OMERO.server")
+    set_if_empty("omero.certificates.owner", "L=OMERO,O=OMERO.server")
     set_if_empty("omero.certificates.key", "server.key")
     set_if_empty("omero.glacier2.IceSSL.CertFile", "server.p12")
     set_if_empty("omero.glacier2.IceSSL.CAs", "server.pem")
@@ -63,7 +67,7 @@ def create_certificates(omerodir):
 
     cn = cfgmap["omero.certificates.commonname"]
     owner = cfgmap["omero.certificates.owner"]
-    days = "365"
+    days = 365
     pkcs12path = os.path.join(certdir, cfgmap["omero.glacier2.IceSSL.CertFile"])
     keypath = os.path.join(certdir, cfgmap["omero.certificates.key"])
     certpath = os.path.join(certdir, cfgmap["omero.glacier2.IceSSL.CAs"])
@@ -82,6 +86,11 @@ def create_certificates(omerodir):
     # Private key
     if os.path.exists(keypath):
         log.info("Using existing key: %s", keypath)
+        with open(keypath, "rb") as pem_openssl_key:
+            rsa_private_key = serialization.load_pem_private_key(
+                pem_openssl_key.read(),
+                password=None,
+            )
     else:
         log.info("Creating self-signed CA key: %s", keypath)
         # Do what `openssl genrsa -out <keypath> <numbits>` would do
@@ -98,23 +107,21 @@ def create_certificates(omerodir):
 
     # Self-signed certificate
     log.info("Creating self-signed certificate: %s", certpath)
-    run_openssl(
-        [
-            "req",
-            "-new",
-            "-x509",
-            "-subj",
-            "{}/CN={}".format(owner, cn),
-            "-days",
-            days,
-            "-key",
-            keypath,
-            "-out",
-            certpath,
-            "-extensions",
-            "v3_ca",
-        ]
+    # Do what `openssl req -x509 ...` would do
+    utcnow = datetime.utcnow()
+    subject = issuer = x509.Name.from_rfc4514_string("{},CN={}".format(owner, cn))
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .not_valid_before(utcnow)
+        .not_valid_after(utcnow + timedelta(days=days))
+        .public_key(rsa_private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .sign(rsa_private_key, SHA256())
     )
+    with open(certpath, "wb") as pem_cert:
+        pem_cert.write(cert.public_bytes(Encoding.PEM))
     created_files.append(certpath)
 
     # PKCS12 format

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ setuptools.setup(
     url="https://github.com/ome/omero-certificates",
     packages=["omero_certificates", "omero.plugins"],
     setup_requires=["setuptools_scm"],
-    install_requires=["omero-py>=5.6.0"],
+    install_requires=[
+        "omero-py>=5.6.0",
+        "cryptography>=36.0.0",
+    ],
     use_scm_version={"write_to": "omero_certificates/_version.py"},
     classifiers=[
         "Environment :: Console",

--- a/tests/unit/test_certificates.py
+++ b/tests/unit/test_certificates.py
@@ -31,7 +31,7 @@ class TestCertificates(object):
             "omero.glacier2.IceSSL.Protocols": "TLS1_0,TLS1_1,TLS1_2",
             "omero.certificates.commonname": "localhost",
             "omero.certificates.key": "server.key",
-            "omero.certificates.owner": "/L=OMERO/O=OMERO.server",
+            "omero.certificates.owner": "L=OMERO,O=OMERO.server",
         }
 
     def test_config_keep_existing(self, tmpdir):
@@ -89,8 +89,8 @@ class TestCertificates(object):
         )
         out = out.decode().splitlines()
         for line in (
-            "subject=L = OMERO, O = OMERO.server, CN = localhost",
-            "issuer=L = OMERO, O = OMERO.server, CN = localhost",
+            "subject=CN = localhost, O = OMERO.server, L = OMERO",
+            "issuer=CN = localhost, O = OMERO.server, L = OMERO",
             "-----BEGIN CERTIFICATE-----",
             "-----END CERTIFICATE-----",
             "-----BEGIN ENCRYPTED PRIVATE KEY-----",


### PR DESCRIPTION
Ports the plugin to use the Python cryptography module rather than calling out to the OpenSSL command line tools which can be error prone, is not cross platform, and for which error conditions are hard to control for.