### PR TITLE
Pre commit ci update config

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,6 +14,7 @@ jobs:
           - '3.7'
           - '3.8'
           - '3.9'
+          - '3.10'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
         args: [--target-version=py36]
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         args: [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
+
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py37, py38, py39, py310
 # https://tox.readthedocs.io/en/latest/config.html#conf-requires
 # Ensure pip is new enough
 requires = pip >= 19.0.0
@@ -13,11 +14,16 @@ deps =
     pytest-rerunfailures
     pytest-xdist
     restructuredtext-lint
-    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.6"
-    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.1.0/zeroc_ice-3.6.5-cp37-cp37m-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.7"
-    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.1.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.8"
-    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.1.0/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
+    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp37-cp37m-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.7"
+    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.8"
+    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
+    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp310-cp310-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.10"
 commands =
     pre-commit run --all-files
+    python setup.py sdist install --record files.txt
+    pytest {posargs:-n4 -rf tests -s}
+[testenv:py37]
+commands =
+    # pre-commit skipped as flake8 6.0.0 requires Python 3.8+
     python setup.py sdist install --record files.txt
     pytest {posargs:-n4 -rf tests -s}


### PR DESCRIPTION
Supersedes #29 

- overrides the `py37` tox configuration to skip pre-commit as the dependencies start requiring Python 3.8+ - see also https://github.com/ome/omero-web/pull/419
- adds Python 3.10 to the testing matrix and use the new Ubuntu 20.04 wheels