### PR TITLE
Set IceSSL Ciphers to exclude DH

### DIFF
--- a/omero_certificates/certificates.py
+++ b/omero_certificates/certificates.py
@@ -36,7 +36,7 @@ def update_config(omerodir):
     set_if_empty("omero.glacier2.IceSSL.CAs", "server.pem")
     set_if_empty("omero.glacier2.IceSSL.Password", "secret")
 
-    set_if_empty("omero.glacier2.IceSSL.Ciphers", "HIGH")
+    set_if_empty("omero.glacier2.IceSSL.Ciphers", "HIGH:!DH")
     set_if_empty("omero.glacier2.IceSSL.ProtocolVersionMax", "TLS1_2")
     set_if_empty("omero.glacier2.IceSSL.Protocols", "TLS1_0,TLS1_1,TLS1_2")
 

--- a/omero_certificates/certificates.py
+++ b/omero_certificates/certificates.py
@@ -36,6 +36,12 @@ def update_config(omerodir):
     set_if_empty("omero.glacier2.IceSSL.CAs", "server.pem")
     set_if_empty("omero.glacier2.IceSSL.Password", "secret")
 
+    if cfgdict.get("omero.glacier2.IceSSL.Ciphers") == "HIGH":
+        msg = (
+            "Configured SSL Ciphers do not explicitly disallow DH keys. "
+            " You might want to review your settings to use HIGH:!DH."
+        )
+        log.warn(msg)
     set_if_empty("omero.glacier2.IceSSL.Ciphers", "HIGH:!DH")
     set_if_empty("omero.glacier2.IceSSL.ProtocolVersionMax", "TLS1_2")
     set_if_empty("omero.glacier2.IceSSL.Protocols", "TLS1_0,TLS1_1,TLS1_2")

--- a/tests/unit/test_certificates.py
+++ b/tests/unit/test_certificates.py
@@ -24,7 +24,7 @@ class TestCertificates(object):
         assert cfg == {
             "omero.glacier2.IceSSL.CAs": "server.pem",
             "omero.glacier2.IceSSL.CertFile": "server.p12",
-            "omero.glacier2.IceSSL.Ciphers": "HIGH",
+            "omero.glacier2.IceSSL.Ciphers": "HIGH:!DH",
             "omero.glacier2.IceSSL.DefaultDir": "/OMERO/certs",
             "omero.glacier2.IceSSL.Password": "secret",
             "omero.glacier2.IceSSL.ProtocolVersionMax": "TLS1_2",
@@ -48,7 +48,7 @@ class TestCertificates(object):
         assert cfg == {
             "omero.glacier2.IceSSL.CAs": "server.pem",
             "omero.glacier2.IceSSL.CertFile": "server.p12",
-            "omero.glacier2.IceSSL.Ciphers": "HIGH",
+            "omero.glacier2.IceSSL.Ciphers": "HIGH:!DH",
             "omero.glacier2.IceSSL.DefaultDir": "/OMERO/certs",
             "omero.glacier2.IceSSL.Password": "secret",
             "omero.glacier2.IceSSL.ProtocolVersionMax": "TLS1_2",


### PR DESCRIPTION
See https://forum.image.sc/t/omero-login-ssl-error-dh-key/79574/12 for more background

The removal of ADH keys in omero-py 5.13.0 has caused some cross-compatiblity issues between server and clients. As described above, this explicitly disallows DH keys from being offered from the server in order to fix this issue. 
The current paradigm of not overriding existing configurations in this plugin is preserved but a warning message is printed if the Ciphers is set to the former `HIGH` value. This means:

- running `omero certificates` on new OMERO installations should set the ciphers to `HIGH:!DH`
- running `omero certificates` on existing OMERO installations with configured self-signed certificates will be a no-op for the Ciphers and admins are expected to manually set `omero.glacier2.IceSSL.Ciphers` to `HIGH:!DH` 
- an entry should be added to the OMERO troubleshooting page to document this issue and instruct how to resolve the issue

If the workflow above feels too prone to errors, an alternative might be to have this plugin always override `omero.glacier2.IceSSL.Ciphers` if a value of `HIGH` is detected but respect any other custom values.

Testing wise, the most obvious minimal scenario is a CentOS 7 deployment. When configured with `omero-certificates 0.2.0`, an OMERO.py client from e.g. Ubuntu 22.04 should fail to connect with a `dh key too small` error. When configured with this PR, the same test should be successful.

Similarly to https://github.com/ome/omero-certificates/pull/27, this change will need to be evaluated against a comprehensive suite of client/server combinations across different operating system/OpenSSL versions. Starting with an initial short list: CentOS 7 + OpenSSL 1.1.1, CentOS 8 + OpenSSL 1.1.1, Debian/Ubuntu + OpenSSL 1.1.1, Debian/Ubuntu + OpenSSL 3.0, OS X + OpenSSL 1.1.1, OSX + OpenSSL 3.0, Windows + OpenSSL 3.0


