### PR TITLE
Allow TLS 1.3 and use ffdhe2048 DHE group

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,14 @@ You can now start your omero server as normal.
 
 This plugin automatically overrides the defaults for the following properties if they're not explicitly set:
 - `omero.glacier2.IceSSL.Ciphers=HIGH`: the default weaker ciphers may not be supported on some systems
-- `omero.glacier2.IceSSL.ProtocolVersionMax=TLS1_2`: Support TLS 1.1 and 1.2, not just 1.0
-- `omero.glacier2.IceSSL.Protocols=TLS1_0,TLS1_1,TLS1_2`: Support TLS 1.1 and 1.2, not just 1.0
+- `omero.glacier2.IceSSL.ProtocolVersionMax=TLS1_3`: Support TLS 1.2 and 1.3
+- `omero.glacier2.IceSSL.Protocols=TLS1_2,TLS1_3`: Support TLS 1.2 and 1.3
+- `omero.glacier2.IceSSL.DH.2048=ffdhe2048.pem`: use a pre-defined 2048-bit Diffie-Hellman group
+
+The pre-defined Diffie-Hellman group is from [RFC 7919](https://www.rfc-editor.org/rfc/rfc7919.txt).  Newer versions of OpenSSL will prefer ECDHE and have their own 2048-bit or greater primes but it's safe to use this one.
+When RHEL 7 (OpenSSL 1.0.2) support is dropped this will be removed.
+
+__NOTE:__ If RHEL 7 is detected, only TLS 1.2 support will be enabled.
 
 The original values can be found on https://docs.openmicroscopy.org/omero/5.6.0/sysadmins/config.html#glacier2
 

--- a/omero_certificates/certificates.py
+++ b/omero_certificates/certificates.py
@@ -8,9 +8,45 @@ import logging
 import os
 import subprocess
 import sys
+from distro import distro
 from omero.config import ConfigXml
 
 log = logging.getLogger(__name__)
+
+
+# ffdhe2048 group from RFC 7919 in PEM format
+# SHA256(ffdhe2048.txt)=
+#   2ef7758563185ad0dc1dbc38ab3a91647701e3ebee344fcf86b52e643bacb721
+#
+# The prime can be validated with OpenSSL:
+#   openssl dhparam -in ffdhe2048.txt -check -text
+#
+# On newer versions of OpenSSL, this will print out that the group has
+# been detected as "ffdhe2048":
+#
+# ...
+#    DH Parameters: (2048 bit)
+#    GROUP: ffdhe2048
+# DH parameters appear to be ok.
+# ...
+#
+# See:
+#  * https://datatracker.ietf.org/doc/html/rfc7919#autoid-31
+FFDHE2048_PEM = """-----BEGIN DH PARAMETERS-----
+MIIBCAKCAQEA//////////+t+FRYortKmq/cViAnPTzx2LnFg84tNpWp4TZBFGQz
++8yTnc4kmz75fS/jY2MMddj2gbICrsRhetPfHtXV/WVhJDP1H18GbtCFY2VVPe0a
+87VXE15/V8k1mE8McODmi3fipona8+/och3xWKE2rec1MKzKT0g6eXq8CrGCsyT7
+YdEIqUuyyOP7uWrat2DX9GgdT0Kj3jlN9K5W7edjcrsZCwenyO4KbXCeAvzhzffi
+7MA0BM0oNC9hkXL+nOmFg/+OTxIy7vKBg8P+OxtMb61zO7X8vC7CIAXFjvGDfRaD
+ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
+-----END DH PARAMETERS-----"""
+
+
+def is_rhel_7():
+    major_version = distro.major_version(best=True)
+    if distro.id() in ("rhel", "centos") and major_version == "7":
+        return True
+    return False
 
 
 def update_config(omerodir):
@@ -39,8 +75,15 @@ def update_config(omerodir):
 
     if sys.platform != "darwin":
         set_if_empty("omero.glacier2.IceSSL.Ciphers", "HIGH")
-    set_if_empty("omero.glacier2.IceSSL.ProtocolVersionMax", "TLS1_2")
-    set_if_empty("omero.glacier2.IceSSL.Protocols", "TLS1_0,TLS1_1,TLS1_2")
+    version_max = "TLS1_3"
+    protocols = "TLS1_2,TLS1_3"
+    if is_rhel_7():
+        # RHEL 7 shipped OpenSSL, version 1.0.2, only supports up to TLS 1.2
+        version_max = "TLS1_2"
+        protocols = "TLS1_2"
+    set_if_empty("omero.glacier2.IceSSL.DH.2048", "ffdhe2048.pem")
+    set_if_empty("omero.glacier2.IceSSL.ProtocolVersionMax", version_max)
+    set_if_empty("omero.glacier2.IceSSL.Protocols", protocols)
 
     cfgdict = cfg.as_map()
     cfg.close()
@@ -63,6 +106,7 @@ def create_certificates(omerodir):
     pkcs12path = os.path.join(certdir, cfgmap["omero.glacier2.IceSSL.CertFile"])
     keypath = os.path.join(certdir, cfgmap["omero.certificates.key"])
     certpath = os.path.join(certdir, cfgmap["omero.glacier2.IceSSL.CAs"])
+    grouppath = os.path.join(certdir, "ffdhe2048.pem")
     password = cfgmap["omero.glacier2.IceSSL.Password"]
 
     try:
@@ -74,6 +118,16 @@ def create_certificates(omerodir):
 
     os.makedirs(certdir, exist_ok=True)
     created_files = []
+
+    # Use pre-defined Diffie-Hellman group from RFC 7919.  Newer versions
+    # of OpenSSL will prefer ECDHE and have their own 2048-bit or greater
+    # primes but it's safe to use this one.  When RHEL 7 (OpenSSL 1.0.2)
+    # support is dropped this can be removed.
+    #
+    # See:
+    #   * https://www.rfc-editor.org/rfc/rfc7919.txt
+    with open(grouppath, "w") as pem:
+        pem.write(FFDHE2048_PEM)
 
     # Private key
     if os.path.exists(keypath):

--- a/omero_certificates/certificates.py
+++ b/omero_certificates/certificates.py
@@ -79,6 +79,12 @@ def update_config(omerodir):
     protocols = "TLS1_2,TLS1_3"
     if is_rhel_7():
         # RHEL 7 shipped OpenSSL, version 1.0.2, only supports up to TLS 1.2
+        log.warn(
+            "Your Linux distribution has been detected as RHEL 7 which will "
+            "reach end of life in June 2024.  TLS 1.3 cannot be enabled and "
+            "upgrading is recommended.\nSee https://www.openmicroscopy.org/"
+            "2023/07/24/linux-distributions.html for more information."
+        )
         version_max = "TLS1_2"
         protocols = "TLS1_2"
     set_if_empty("omero.glacier2.IceSSL.DH.2048", "ffdhe2048.pem")

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     url="https://github.com/ome/omero-certificates",
     packages=["omero_certificates", "omero.plugins"],
     setup_requires=["setuptools_scm"],
-    install_requires=["omero-py>=5.6.0"],
+    install_requires=["omero-py>=5.6.0", "distro==1.8.0"],
     use_scm_version={"write_to": "omero_certificates/_version.py"},
     classifiers=[
         "Environment :: Console",

--- a/tests/unit/test_certificates.py
+++ b/tests/unit/test_certificates.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
 
+from hashlib import sha256
+
 from omero.config import ConfigXml
 from omero_certificates.certificates import create_certificates, update_config
 
@@ -25,10 +27,11 @@ class TestCertificates(object):
             "omero.glacier2.IceSSL.CAs": "server.pem",
             "omero.glacier2.IceSSL.CertFile": "server.p12",
             "omero.glacier2.IceSSL.Ciphers": "HIGH",
+            "omero.glacier2.IceSSL.DH.2048": "ffdhe2048.pem",
             "omero.glacier2.IceSSL.DefaultDir": "/OMERO/certs",
             "omero.glacier2.IceSSL.Password": "secret",
-            "omero.glacier2.IceSSL.ProtocolVersionMax": "TLS1_2",
-            "omero.glacier2.IceSSL.Protocols": "TLS1_0,TLS1_1,TLS1_2",
+            "omero.glacier2.IceSSL.ProtocolVersionMax": "TLS1_3",
+            "omero.glacier2.IceSSL.Protocols": "TLS1_2,TLS1_3",
             "omero.certificates.commonname": "localhost",
             "omero.certificates.key": "server.key",
             "omero.certificates.owner": "/L=OMERO/O=OMERO.server",
@@ -49,10 +52,11 @@ class TestCertificates(object):
             "omero.glacier2.IceSSL.CAs": "server.pem",
             "omero.glacier2.IceSSL.CertFile": "server.p12",
             "omero.glacier2.IceSSL.Ciphers": "HIGH",
+            "omero.glacier2.IceSSL.DH.2048": "ffdhe2048.pem",
             "omero.glacier2.IceSSL.DefaultDir": "/OMERO/certs",
             "omero.glacier2.IceSSL.Password": "secret",
-            "omero.glacier2.IceSSL.ProtocolVersionMax": "TLS1_2",
-            "omero.glacier2.IceSSL.Protocols": "TLS1_0,TLS1_1,TLS1_2",
+            "omero.glacier2.IceSSL.ProtocolVersionMax": "TLS1_3",
+            "omero.glacier2.IceSSL.Protocols": "TLS1_2,TLS1_3",
             "omero.certificates.commonname": "omero.example.org",
             "omero.certificates.key": "server.key",
             "omero.certificates.owner": "/L=universe/O=42",
@@ -72,8 +76,14 @@ class TestCertificates(object):
         cfg = get_config(omerodir)
         assert cfg["omero.glacier2.IceSSL.DefaultDir"] == os.path.join(datadir, "certs")
 
-        for filename in ("server.key", "server.p12", "server.pem"):
+        for filename in ("server.key", "server.p12", "server.pem", "ffdhe2048.pem"):
             assert os.path.isfile(os.path.join(datadir, "certs", filename))
+
+        with open(os.path.join(datadir, "certs", "ffdhe2048.pem")) as pem:
+            assert (
+                sha256(pem.read().encode("ascii")).hexdigest()
+                == "2ef7758563185ad0dc1dbc38ab3a91647701e3ebee344fcf86b52e643bacb721"
+            )
 
         out = subprocess.check_output(
             [


### PR DESCRIPTION
The community [^1] has begun to notice issues connecting to servers with the 1024-bit prime used by OpenSSL 1.0.2 on RHEL 7. Specifically, errors such as `dh key too small` coming from newer Debian derived OpenSSL versions [^2] or `DH ServerKeyExchange does not comply to algorithm constraints` (https://github.com/ome/omero-blitz/pull/139#issuecomment-1653103414) from the JVM.

The reasons for this stem from crypto community research culminating in the logjam attack being detailed and following the publication of the Snowden documents suggesting that the NSA may already be exploiting 1024-bit Diffie-Hellman to decrypt VPN traffic. This work was published [^3] in late 2015 and a supplementary website [^4] was built detailing scope and exposure as well as providing mitigations and advice. This advice includes a recommendation that you generate a 2048-bit group.

To understand what "a 2048-bit group" is I recommend watching the following two YouTube videos (there are many dozens on the topic if you find them unhelpful; key search terms are "diffie hellman key exchange", "diffie hellman groups", "discrete logarithm problem"):
 * https://www.youtube.com/watch?v=M-0qt6tdHzk
 * https://www.youtube.com/watch?v=SL7J8hPKEWY

and follow that up by reading these two Wikipedia pages:
 * https://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange
 * https://en.wikipedia.org/wiki/Safe_and_Sophie_Germain_primes

The key take homes are:
1. A group consists of a primitive root or generator `g` and a prime `p`
2. The group is considered public information and is exchanged in the clear, publicly with anyone who asks
3. Generating even a 2048-bit group by deriving a safe prime is computationally expensive and must be done correctly to not compromise security
4. Given [3], the exchanged group is explicitly trusted as it is computationally unreasonable for a client to check a group contains a safe prime during each TLS handshake

I expect we can all agree that the NSA is unlikely to be interested in the encrypted traffic flowing between clients and our OMERO servers so we probably don't care that we are using 1024-bit primes but we also don't want to make the security of our cryptosystem worse by using unsafe or poorly derived ones. It is also nearly 8 years on from the logjam paper and the community has done lots of great work since then.

Consequently, this PR uses the predefined ffdhe2048 group from RFC 7919 [^5] which is consistent with the work from other communities such as IKE group 14 [^6] and is already used by the JVM [^7]. It also performs the long overdue work of enabling TLS 1.3 by default on all platforms other than RHEL 7 and removes support for the outdated TLS 1.0 and 1.1 protocols. Their use is already disabled by all the major web browsers [^8] and is forbidden by most organizational security policies. To fully utilize the TLS work, clients will need ome/omero-py#377 and ome/omero-blitz#139 which should be released in the next couple of months.

For people who want to use the ffdhe2048 group by performing the work by hand on existing systems I recommend:

```
curl https://ssl-config.mozilla.org/ffdhe2048.txt > /OMERO/certs/ffdhe2048.pem
omero config set omero.glacier2.IceSSL.DH.2048 ffdhe2048.pem
```

For reference:
 * https://doc.zeroc.com/ice/3.6/property-reference/icessl#id-.IceSSL.*v3.6-IceSSL.DH.bits

If you are on macOS where SecureTransport is used rather than OpenSSL you will need to convert from PEM to DER format and use a different OMERO server configuration option:

```
openssl dhparam -in ffdhe2048.pem -out ffdhe2048.der -outform DER
omero config set omero.glacier2.IceSSL.DHParams ffdhe2048.der
```

For reference:
 * https://doc.zeroc.com/ice/3.6/property-reference/icessl#id-.IceSSL.*v3.6-IceSSL.DHParams

Special thanks to @erickmartins, @JulianHn, and @sbesson for all the existing work surrounding this issue!

[^1]: https://forum.image.sc/t/omero-login-ssl-error-dh-key/79574
[^2]: https://wiki.debian.org/ContinuousIntegration/TriagingTips/openssl-1.1.1
[^3]: https://weakdh.org/imperfect-forward-secrecy-ccs15.pdf
[^4]: https://weakdh.org/
[^5]: https://www.rfc-editor.org/rfc/rfc7919#appendix-A.1
[^6]: https://datatracker.ietf.org/doc/html/rfc3526#section-3
[^7]: https://www.java.com/en/configure_crypto.html#TLSsupportforx25519andx448
[^8]: https://security.googleblog.com/2018/10/modernizing-transport-security.html