### PR TITLE
Map contributors to use canonical real names and email addresses

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Josh Moore <josh@openmicroscopy.org> <j.a.moore@dundee.ac.uk>
+Sébastien Besson <sbesson@glencoesoftware.com> <seb.besson@gmail.com>
+Simon Li <spli@dundee.ac.uk> <orpheus+devel@gmail.com>


### PR DESCRIPTION
Similar to the changes made in https://github.com/ome/openmicroscopy/pull/6349 and other repositories with various contributions 