### PR TITLE
Build

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -48,6 +48,6 @@ jobs:
           python -mpip install wheel
           python setup.py sdist bdist_wheel
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.3.0
+        uses: pypa/gh-action-pypi-publish@v1.8.14
         with:
           password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -45,8 +45,8 @@ jobs:
           python-version: '3.9'
       - name: Build package
         run: |
-          python -mpip install wheel
-          python setup.py sdist bdist_wheel
+          python -mpip install build
+          python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.14
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ deps =
     pytest-xdist
     restructuredtext-lint
     setuptools
-    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.8"
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp310-cp310-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.10"
     https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl; platform_system=="Linux" and python_version=="3.11"

--- a/tox.ini
+++ b/tox.ini
@@ -14,11 +14,12 @@ deps =
     pytest-xdist
     restructuredtext-lint
     setuptools
+    build
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.9"
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.2.0/zeroc_ice-3.6.5-cp310-cp310-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.10"
     https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl; platform_system=="Linux" and python_version=="3.11"
     https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp312-cp312-manylinux_2_28_x86_64.whl; platform_system=="Linux" and python_version=="3.12"
 commands =
     pre-commit run --all-files
-    python setup.py sdist install --record files.txt
+    python -m build
     pytest {posargs:-n4 -rf tests -s}


### PR DESCRIPTION
Update actions and Update PyPI publish workflow to use build instead of sdist
Drop Python 3.8